### PR TITLE
NODE-636 Add DangerousPaths route

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -17,6 +17,14 @@ module.exports = {
     inputs: ['query'],
     sinks: sinks.cmdInjectionSemanticChainedCommands
   },
+  cmdInjectionSemanticDangerousPaths: {
+    base: '/cmdInjectionSemanticDangerousPaths',
+    name: 'Command Injection Semantic Dangerous Paths',
+    link: 'https://www.owasp.org/index.php/Command_Injection',
+    products: ['Protect'],
+    inputs: ['query'],
+    sinks: sinks.cmdInjectionSemanticDangerousPaths
+  },
   nosqlInjection: {
     base: '/nosqlInjection',
     name: 'NoSQL Injection',

--- a/lib/sinks/cmdInjectionSemanticDangerousPaths.js
+++ b/lib/sinks/cmdInjectionSemanticDangerousPaths.js
@@ -1,0 +1,29 @@
+'use strict';
+const cp = require('child_process');
+
+const pre = (str) => `<pre>${str}</pre>`;
+
+/**
+ * @param {string} input user input string
+ * @param {Object} opts
+ * @param {boolean=} opts.safe are we calling the sink safely?
+ * @param {boolean=} opts.noop are we calling the sink as a noop?
+ */
+module.exports['child_process.exec'] = async function exec(
+  input,
+  { safe = false, noop = false } = {}
+) {
+  if (safe) return 'SAFE';
+  if (noop) return 'NOOP';
+
+  return new Promise((resolve) => {
+    cp.exec("/bin/sh -c 'cat /tmp/foo.txt /etc/passwd'", (err, data) => {
+      if (err) {
+        console.log(
+          `exec failed on /bin/sh -c 'cat /tmp/foo.txt /etc/passwd', err: ${err.message}`
+        );
+      }
+      resolve(pre(data.toString()));
+    });
+  });
+};

--- a/lib/sinks/index.js
+++ b/lib/sinks/index.js
@@ -5,6 +5,7 @@ module.exports = {
   sqlInjection: require('./sqlInjection'),
   cmdInjection: require('./cmdInjection'),
   cmdInjectionSemanticChainedCommands: require('./cmdInjectionSemanticChainedCommands'),
+  cmdInjectionSemanticDangerousPaths: require('./cmdInjectionSemanticDangerousPaths'),
   pathTraversal: require('./pathTraversal'),
   ssjs: require('./ssjs'),
   ssrf: require('./ssrf'),


### PR DESCRIPTION
This PR adds:

- A new route for the CMDi DangerousPaths sub-rule

Pretty much followed suit with what @pmcclory-contrast did here (https://github.com/Contrast-Security-OSS/test-bench-utils/pull/13) for the ChainedCommand rule

You can test this by:

1. `npm link` here and in your `test-bench-content` local directory.
2. `npm link @contast/test-bench-utils @contrast-test-bench-content` in a sample app directory.
3. Navigate to route and observe the rule get reported/blocked in BLOCK/MONITOR modes in TS UI.

Example:
<img width="1680" alt="Screen Shot 2020-02-28 at 2 14 34 PM" src="https://user-images.githubusercontent.com/14120224/75579852-acac6580-5a34-11ea-83fb-d7e3b99358f3.png">
